### PR TITLE
Change scrollbar background to base03

### DIFF
--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -65,7 +65,7 @@
 @tree-view-background-color: @tool-panel-background-color;
 @tree-view-border-color: @tool-panel-border-color;
 
-@scroll-background: @background-color-highlight;
+@scroll-background: @base03;
 @scroll-thumb: @overlay-border-color;
 
 @ui-site-color-1: @background-color-success; // green


### PR DESCRIPTION
This PR will fix the similar issue that atom-dark theme had with tree view scroll bar in [issue #4578](https://github.com/atom/atom/issues/4578) where the scroll bar background color will change once it overlay with some file name in tree view.

